### PR TITLE
Shuffle test order

### DIFF
--- a/share/fish-tank/functions/__tank_run_tests.fish
+++ b/share/fish-tank/functions/__tank_run_tests.fish
@@ -3,7 +3,7 @@ function __tank_run_tests
 	functions -n | grep test_
 		eval $argv >/dev/null
 		functions -n | grep test_
-	end | sort | uniq -u)
+	end | sort | uniq -u | shuf)
 
 	for test in $tests
 		emit test_run $test

--- a/share/fish-tank/functions/tank_run.fish
+++ b/share/fish-tank/functions/tank_run.fish
@@ -8,5 +8,5 @@ function tank_run
 		end
 	end
 
-	tank_run_suite (functions -q | grep suite_)
+	tank_run_suite (functions -q | grep suite_ | shuf)
 end


### PR DESCRIPTION
This will shuffle the order of suites and tests. This should help to catch some
false positive tests with order dependant passes.
