### PR TITLE
File and directory stubbing

### DIFF
--- a/share/fish-tank/features/stubs.fish
+++ b/share/fish-tank/features/stubs.fish
@@ -50,6 +50,47 @@ function unstub_var
 	set -e $backup
 end
 
+function stub_dir
+	set -l dirname (mktemp -d fish-tank_stub_dir.XXXXXXXXXX)
+	set -l funcname __fish-tank_stub_dir_(basename $dirname)
+
+	# Make sure directory is erased when test finishes
+	function $funcname -V funcname -V dirname -e test_finished -e test_unstub
+		command rm -rf $dirname
+		functions -e $funcname
+	end
+
+	if set -q argv[1]
+		set dirname $dirname/$argv[1]
+		mkdir $dirname
+	end
+
+	echo $dirname
+end
+
+function stub_file
+	set -l filename
+	set -l funcname
+
+	if set -q argv[1]
+		set -l dirname (stub_dir)
+		set filename $dirname/$argv[1]
+		touch $filename
+
+	else
+		set filename (mktemp fish-tank_stub_file.XXXXXXXXXX)
+		set -l funcname __fish-tank_stub_file_(basename $filename)
+
+		# Make sure file is erased when test finishes
+		function $funcname -V funcname -V filename -e test_finished -e test_unstub
+			command rm $filename
+			functions -e $funcname
+		end
+	end
+
+	echo $filename
+end
+
 # Events
 function __tank_test_stub_teardown -e test_finished -e test_unstub
 	for target in $__tank_stubs

--- a/share/fish-tank/tank.fish
+++ b/share/fish-tank/tank.fish
@@ -11,6 +11,6 @@ if not type -t source >/dev/null
 	end
 end
 
-source $tank_path/features/assertions.fish
-source $tank_path/features/reporting.fish
-source $tank_path/features/stubs.fish
+for feature in $tank_path/features/*.fish
+	source $feature
+end

--- a/test/test_stubs.fish
+++ b/test/test_stubs.fish
@@ -63,6 +63,44 @@ function suite_stubs
 		refute (functions -q dummy_stub)
 		assert_equal original $dummy
 	end
+
+	function test_directory_stubbing
+		set -l dirname (stub_dir)
+		assert (test -d $dirname)
+
+		emit test_unstub
+
+		refute (test -d $dirname)
+	end
+
+	function test_directory_stubbing_with_explicit_name
+		set -l dirname (stub_dir stubbed)
+		assert (test -d $dirname)
+		assert_equal stubbed (basename $dirname)
+
+		emit test_unstub
+
+		refute (test -d $dirname)
+	end
+
+	function test_file_stubbing
+		set -l filename (stub_file)
+		assert (test -f $filename)
+
+		emit test_unstub
+
+		refute (test -f $filename)
+	end
+
+	function test_file_stubbing_with_explicit_name
+		set -l filename (stub_file stubbed)
+		assert (test -f $filename)
+		assert_equal stubbed (basename $filename)
+
+		emit test_unstub
+
+		refute (test -f $filename)
+	end
 end
 
 if not set -q tank_running


### PR DESCRIPTION
Adds `stub_dir` and `stub_file` to create a temporary directory or file that
will be removed after the tests finish.

It also supports giving a name, which might be used when a test needs a 
explicit directory or filename.
